### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
-#PinGo 
-##纯Swift编写的仿“随遇”App
+# PinGo 
+## 纯Swift编写的仿“随遇”App
 
-###概述
+### 概述
 * 此项目是为了巩固Swift掌握而编写的，素材均来自“随遇”官方App
 * 用Storyboard+Xib+Autolayout的方式来实现UI部分
 * 由于项目不复杂，所以目录结构分的比较简单，一个模块对应一个文件夹
 * 并没有多复杂的逻辑处理，所以注释不多
 * 在UI方面有一些小技巧可供参考
 
-###屏幕截图
+### 屏幕截图
 ![jpg](https://github.com/gaowanli/PinGo/blob/master/Screenshots.jpg) 
 
-###已有功能
+### 已有功能
 * TabBar对应的几个控制器的首页展示功能
 * Profile对应的“谁看过我”
 * 头部标签切换
 * 首页右拉刷新
 
-###TODO
+### TODO
 * 完成一些比较有意思的详情页面，比如登陆、个人相册
 
-###待修改的bug
+### 待修改的bug
 * 首页右拉刷新 CollectionView在开启PagingEnabled属性后会发生偏移
 
-###适配
+### 适配
 * iOS 9.0+
 * Xcode 7.2
 
-###用到的第三方库
+### 用到的第三方库
 * Alamofire 
 * Kingfisher
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
